### PR TITLE
Return cursor to inside span

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -40,10 +40,11 @@ export default class ColoredFont extends Plugin {
           hotkeys: [],
           editorCallback: (editor: Editor, view: MarkdownView) => {
             let selection = editor.getSelection();
-            editor.replaceSelection(`<span style="color:${this.curColor}">${selection}</span>`)
+            editor.replaceSelection(`<span style="color:${this.curColor}">${selection}</span>`);
 
-            const curserEnd = editor.getCursor("to");
-            editor.setCursor(curserEnd.line, curserEnd.ch + 1);
+            const cursorEnd = editor.getCursor("to");
+            cursorEnd.ch -= 7;
+            editor.setCursor(cursorEnd);
           }
         });
         


### PR DESCRIPTION
Just a small change to keep consistent with Obsidian's behavior on bolding and italics. Figured it would be better on a usability standpoint.

Keen to hear your thoughts and love the work on this extension :slightly_smiling_face: