### PR TITLE
Add "Remove Color Under Cursor" command

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -148,6 +148,7 @@ export default class ColoredFont extends Plugin {
           }
         }
     });
+  }
 
     openColorModal() {
       new ColorModal(this.app, this, this.curColor, (result) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,45 +83,78 @@ export default class ColoredFont extends Plugin {
           callback: () => this.selectColor(this.curIndex == 0 ? (this.cellCount - 1) : this.curIndex - 1)
         })
 
-        // --------------------  Remove Color Under Cursor-------------------- //
+        // --------------------  Remove Color -------------------- //
         this.addCommand({
           id: "remove-color",
-          name: "Remove Color Under Cursor",
+          name: "Remove Color From Selection / Under Cursor",
           hotkeys: [],
           editorCallback:(editor, view) => {
             const fromCursor = editor.getCursor('from');
             const toCursor = editor.getCursor('to');
         
-            // Currently only works for single line, no selection, just cursor
-            if (fromCursor.ch != toCursor.ch && fromCursor.line != toCursor.line) {
-              return;
-            }
-
-            const cursor = fromCursor;
-            const line = editor.getLine(cursor.line);
-
             const spanRegex = /<span style=".*?">(.*?)<\/span>(.*?)/;
-            let d = 0;
-            let sub = line.substring(d);
+            const spanRegexG = /<span style=".*?">(.*?)<\/span>(.*?)/g;
+            const beginRegex = /<span style=".*?">/;
+            const endString = "</span>";
 
-            let found = false;
-            while (!found && sub.search(spanRegex) != -1) {
-              const pos = sub.search(spanRegex);
-              d += pos;
-              const close = sub.substring(pos).search('</span>');
+            if (fromCursor.ch == toCursor.ch && fromCursor.line == toCursor.line) {
+              const cursor = fromCursor;
+              const line = editor.getLine(cursor.line);
 
-              if (cursor.ch >= d && cursor.ch < d + close + '</span>'.length) {
-                const newLine = line.substring(0, d) + line.substring(d).replace(spanRegex, '$1$2');
-                editor.setLine(cursor.line, newLine);
-                editor.setCursor({ line: cursor.line, ch: d });
-                found = true;
-              } else {
-                sub = sub.substring(pos+1);
+              let d = 0;
+              let sub = line.substring(d);
+
+              let found = false;
+              while (!found && sub.search(spanRegex) != -1) {
+                const pos = sub.search(spanRegex);
+                d += pos;
+                const close = sub.substring(pos).search(endString);
+
+                if (cursor.ch >= d && cursor.ch < d + close + endString.length) {
+                  const newLine = line.substring(0, d) + line.substring(d).replace(spanRegex, '$1$2');
+                  editor.setLine(cursor.line, newLine);
+                  editor.setCursor({ line: cursor.line, ch: d });
+                  found = true;
+                } else {
+                  sub = sub.substring(pos+1);
+                }
+              }
+          } else {
+            const lines = [...Array(toCursor.line - fromCursor.line + 1)]
+              .map((x, i) => editor.getLine(fromCursor.line + i));
+            const lastInd = lines.length - 1;
+            lines[lastInd] = lines[lastInd].substring(0, toCursor.ch);
+            lines[0] = lines[0].substring(fromCursor.ch);
+            
+            let unendedBeginIndex = null;
+            for (const [i, l] of lines.entries()) {
+              let newLine = l;
+              newLine = newLine.replaceAll(spanRegexG, '$1$2')
+
+              lines[i] = newLine;
+
+              if (newLine.search(endString) != -1 && unendedBeginIndex) {
+                const j = unendedBeginIndex.line;
+                const ch = unendedBeginIndex.ch;
+                lines[j] = 
+                  lines[j].substring(0, ch) + 
+                  lines[j].substring(ch).replace(beginRegex, '');
+                lines[i] = lines[i].replace(endString, '');
+              }
+
+              if (newLine.search(beginRegex) != -1) {
+                unendedBeginIndex = {line: i, ch: newLine.search(beginRegex)}
               }
             }
+
+            lines[0] = editor.getLine(fromCursor.line).substring(0, fromCursor.ch) + lines[0];
+            lines[lastInd] = lines[lastInd] + editor.getLine(toCursor.line).substring(toCursor.ch);
+
+            lines.map((l, i) => editor.setLine(fromCursor.line + i, l));
+            editor.setCursor(fromCursor);
           }
-        });
-    }
+        }
+    });
 
     selectColor(newIndex: number) {      
       this.prevIndex = this.curIndex;

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,8 @@ export default class ColoredFont extends Plugin {
             editor.setCursor(cursorEnd);
           }
         });
+
+
         
         this.addCommand({
           id: 'get-color-input',
@@ -80,6 +82,45 @@ export default class ColoredFont extends Plugin {
           hotkeys: [],
           callback: () => this.selectColor(this.curIndex == 0 ? (this.cellCount - 1) : this.curIndex - 1)
         })
+
+        // --------------------  Remove Color Under Cursor-------------------- //
+        this.addCommand({
+          id: "remove-color",
+          name: "Remove Color Under Cursor",
+          hotkeys: [],
+          editorCallback:(editor, view) => {
+            const fromCursor = editor.getCursor('from');
+            const toCursor = editor.getCursor('to');
+        
+            // Currently only works for single line, no selection, just cursor
+            if (fromCursor.ch != toCursor.ch && fromCursor.line != toCursor.line) {
+              return;
+            }
+
+            const cursor = fromCursor;
+            const line = editor.getLine(cursor.line);
+
+            const spanRegex = /<span style=".*?">(.*?)<\/span>(.*?)/;
+            let d = 0;
+            let sub = line.substring(d);
+
+            let found = false;
+            while (!found && sub.search(spanRegex) != -1) {
+              const pos = sub.search(spanRegex);
+              d += pos;
+              const close = sub.substring(pos).search('</span>');
+
+              if (cursor.ch >= d && cursor.ch < d + close + '</span>'.length) {
+                const newLine = line.substring(0, d) + line.substring(d).replace(spanRegex, '$1$2');
+                editor.setLine(cursor.line, newLine);
+                editor.setCursor({ line: cursor.line, ch: d });
+                found = true;
+              } else {
+                sub = sub.substring(pos+1);
+              }
+            }
+          }
+        });
     }
 
     selectColor(newIndex: number) {      


### PR DESCRIPTION
I didn't find any command to remove an assigned color, so I've implemented one. 
(Although I saw a mention of it in #16.)

Currently only works for a single color, under the cursor, with no text selected. 

Nice work BTW, thank you for the plugin!